### PR TITLE
Install gold linker on Fedora 41

### DIFF
--- a/swift-ci/main/fedora/41/Dockerfile
+++ b/swift-ci/main/fedora/41/Dockerfile
@@ -29,7 +29,8 @@ RUN yum install -y \
   libstdc++-devel     \
   libstdc++-static    \
   ninja-build         \
-  gnupg
+  gnupg               \
+  binutils-gold
 
 ARG SWIFT_PLATFORM=fedora39
 ARG SWIFT_VERSION=6.1


### PR DESCRIPTION
The gold linker is required when building targts for several lldb tests. This patch resolves those test failures for oss-swift-package-fedora-41.