### PR TITLE
Update the Static SDK for Linux

### DIFF
--- a/swift-ci/sdks/static-linux/resources/patches/musl/0001-iconv-fix-erroneous-input-validation-in-EUC-KR-decod.patch
+++ b/swift-ci/sdks/static-linux/resources/patches/musl/0001-iconv-fix-erroneous-input-validation-in-EUC-KR-decod.patch
@@ -1,0 +1,38 @@
+>From e5adcd97b5196e29991b524237381a0202a60659 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Sun, 9 Feb 2025 10:07:19 -0500
+Subject: [PATCH] iconv: fix erroneous input validation in EUC-KR decoder
+
+as a result of incorrect bounds checking on the lead byte being
+decoded, certain invalid inputs which should produce an encoding
+error, such as "\xc8\x41", instead produced out-of-bounds loads from
+the ksc table.
+
+in a worst case, the loaded value may not be a valid unicode scalar
+value, in which case, if the output encoding was UTF-8, wctomb would
+return (size_t)-1, causing an overflow in the output pointer and
+remaining buffer size which could clobber memory outside of the output
+buffer.
+
+bug report was submitted in private by Nick Wellnhofer on account of
+potential security implications.
+---
+ src/locale/iconv.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/locale/iconv.c b/src/locale/iconv.c
+index 9605c8e9..008c93f0 100644
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -502,7 +502,7 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 			if (c >= 93 || d >= 94) {
+ 				c += (0xa1-0x81);
+ 				d += 0xa1;
+-				if (c >= 93 || c>=0xc6-0x81 && d>0x52)
++				if (c > 0xc6-0x81 || c==0xc6-0x81 && d>0x52)
+ 					goto ilseq;
+ 				if (d-'A'<26) d = d-'A';
+ 				else if (d-'a'<26) d = d-'a'+26;
+-- 
+2.21.0
+

--- a/swift-ci/sdks/static-linux/resources/patches/musl/0002-iconv-harden-UTF-8-output-code-path-against-input-de.patch
+++ b/swift-ci/sdks/static-linux/resources/patches/musl/0002-iconv-harden-UTF-8-output-code-path-against-input-de.patch
@@ -1,0 +1,38 @@
+>From c47ad25ea3b484e10326f933e927c0bc8cded3da Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 12 Feb 2025 17:06:30 -0500
+Subject: [PATCH] iconv: harden UTF-8 output code path against input decoder
+ bugs
+
+the UTF-8 output code was written assuming an invariant that iconv's
+decoders only emit valid Unicode Scalar Values which wctomb can encode
+successfully, thereby always returning a value between 1 and 4.
+
+if this invariant is not satisfied, wctomb returns (size_t)-1, and the
+subsequent adjustments to the output buffer pointer and remaining
+output byte count overflow, moving the output position backwards,
+potentially past the beginning of the buffer, without storing any
+bytes.
+---
+ src/locale/iconv.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/locale/iconv.c b/src/locale/iconv.c
+index 008c93f0..52178950 100644
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -545,6 +545,10 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 				if (*outb < k) goto toobig;
+ 				memcpy(*out, tmp, k);
+ 			} else k = wctomb_utf8(*out, c);
++			/* This failure condition should be unreachable, but
++			 * is included to prevent decoder bugs from translating
++			 * into advancement outside the output buffer range. */
++			if (k>4) goto ilseq;
+ 			*out += k;
+ 			*outb -= k;
+ 			break;
+-- 
+2.21.0
+
+

--- a/swift-ci/sdks/static-linux/scripts/fetch-source.sh
+++ b/swift-ci/sdks/static-linux/scripts/fetch-source.sh
@@ -52,9 +52,14 @@ function usage {
     cat <<EOF
 usage: fetch-source.sh [--swift-scheme <scheme>|--swift-tag <tag>
                                                |--swift-version <version>]
-                       [--musl-version <version>] [--libxml2-version <version>]
-                       [--curl-version <version>]
                        [--boringssl-version <version>]
+                       [--bzip2-version <version>]
+                       [--curl-version <version>]
+                       [--libarchive-version <version>]
+                       [--libxml2-version <version>]
+                       [--mimalloc-version <version>]
+                       [--musl-version <version>]
+                       [--xz-version <version>]
                        [--zlib-version <version>]
                        [--clone-with-ssh]
                        [--source-dir <path>]
@@ -72,10 +77,14 @@ SDK for Swift.  Options are:
                       If <version> starts with "scheme:" or "tag:", it will
                       select a scheme or tag; otherwise it will be treated as
                       a version number.
-  --musl-version <version>
-  --libxml2-version <version>
-  --curl-version <version>
   --boringssl-version <version>
+  --bzip2-version <version>
+  --curl-version <version>
+  --libarchive-version <version>
+  --libxml2-version <version>
+  --mimalloc-version <version>
+  --musl-version <version>
+  --xz-version <version>
   --zlib-version <version>
                       Select the versions of other dependencies.
 EOF
@@ -89,16 +98,28 @@ if [[ -z "${MUSL_VERSION}" ]]; then
     MUSL_VERSION=1.2.5
 fi
 if [[ -z "${LIBXML2_VERSION}" ]]; then
-    LIBXML2_VERSION=2.12.7
+    LIBXML2_VERSION=2.14.5
 fi
 if [[ -z "${CURL_VERSION}" ]]; then
-    CURL_VERSION=8.7.1
+    CURL_VERSION=8.15.0
 fi
 if [[ -z "${BORINGSSL_VERSION}" ]]; then
-    BORINGSSL_VERSION=fips-20220613
+    BORINGSSL_VERSION=817ab07ebb53da35afea409ab9328f578492832d
 fi
 if [[ -z "${ZLIB_VERSION}" ]]; then
     ZLIB_VERSION=1.3.1
+fi
+if [[ -z "${BZIP2_VERSION}" ]]; then
+    BZIP2_VERSION=1.0.8
+fi
+if [[ -z "${LIBARCHIVE_VERSION}" ]]; then
+    LIBARCHIVE_VERSION=3.8.1
+fi
+if [[ -z "${MIMALLOC_VERSION}" ]]; then
+    MIMALLOC_VERSION=2.2.4
+fi
+if [[ -z "${XZ_VERSION}" ]]; then
+    XZ_VERSION=5.8.1
 fi
 
 clone_with_ssh=false
@@ -120,6 +141,14 @@ while [ "$#" -gt 0 ]; do
             BORINGSSL_VERSION="$2"; shift ;;
         --zlib-version)
             ZLIB_VERSION="$2"; shift ;;
+        --bzip2-version)
+            BZIP2_VERSION="$2"; shift ;;
+        --libarchive-version)
+            LIBARCHIVE_VERSION="$2"; shift ;;
+        --mimalloc-version)
+            MIMALLOC_VERSION="$2"; shift ;;
+        --xz-version)
+            XZ_VERSION="$2"; shift ;;
         --clone-with-ssh)
             clone_with_ssh=true ;;
         --source-dir)
@@ -208,3 +237,35 @@ header "Fetching zlib"
 pushd zlib >/dev/null 2>&1
 git checkout v${ZLIB_VERSION}
 popd >/dev/null 2>&1
+
+# Fetch bzip2
+header "Fetching bzip2"
+
+[[ -d bzip2 ]] | git clone git://sourceware.org/git/bzip2.git
+pushd bzip2 >/dev/null 2>&1
+git checkout bzip2-${BZIP2_VERSION}
+popd >/dev/null 2>&1
+
+# Fetch libarchive
+header "Fetching libarchive"
+
+[[ -d libarchive ]] | git clone ${github}libarchive/libarchive.git
+pushd libarchive >/dev/null 2>&1
+git checkout v${LIBARCHIVE_VERSION}
+popd >/dev/null 2>&1
+
+# Fetch mimalloc
+header "Fetching mimalloc"
+
+[[ -d mimalloc ]]  | git clone ${github}microsoft/mimalloc.git
+pushd mimalloc >/dev/null 2>&1
+git checkout v${MIMALLOC_VERSION}
+popd
+
+# Fetch xz-utils
+header "Fetching xz"
+
+[[ -d xz ]] | git clone ${github}tukaani-project/xz.git
+pushd xz >/dev/null 2>&1
+git checkout v${XZ_VERSION}
+popd


### PR DESCRIPTION
Updated the versions of:

- libxml2 (2.14.5)
- curl (8.15.0)
- BoringSSL (newer SHA)

and added:

- bzip2 (1.0.8)
- xz-utils (5.8.1)
- libarchive (3.8.1)
- mimalloc (2.2.4)

Plus two security patches for musl to fix CVE-2025-26519.

Also link mimalloc by default, so programs using the Static SDK for Linux get a better memory allocator out of the box.

rdar://156423711