### PR TITLE
Nightly debian and fedora images shouldn't set build-user

### DIFF
--- a/nightly-6.1/debian/12/Dockerfile
+++ b/nightly-6.1/debian/12/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils-gold \
@@ -64,10 +61,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/debian/12/buildx/Dockerfile
+++ b/nightly-6.1/debian/12/buildx/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12 as Base
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils-gold \
@@ -74,10 +71,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/fedora/39/Dockerfile
+++ b/nightly-6.1/fedora/39/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -66,10 +63,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/fedora/39/buildx/Dockerfile
+++ b/nightly-6.1/fedora/39/buildx/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39 AS base
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -76,10 +73,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/debian/12/Dockerfile
+++ b/nightly-6.2/debian/12/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils-gold \
@@ -64,10 +61,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/debian/12/buildx/Dockerfile
+++ b/nightly-6.2/debian/12/buildx/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12 as Base
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils-gold \
@@ -74,10 +71,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/fedora/39/Dockerfile
+++ b/nightly-6.2/fedora/39/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -66,10 +63,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/fedora/39/buildx/Dockerfile
+++ b/nightly-6.2/fedora/39/buildx/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39 AS base
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -76,10 +73,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/12/Dockerfile
+++ b/nightly-main/debian/12/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils-gold \
@@ -67,10 +64,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/12/buildx/Dockerfile
+++ b/nightly-main/debian/12/buildx/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:12 as Base
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
@@ -76,10 +73,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/fedora/39/Dockerfile
+++ b/nightly-main/fedora/39/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -66,10 +63,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/fedora/39/buildx/Dockerfile
+++ b/nightly-main/fedora/39/buildx/Dockerfile
@@ -2,9 +2,6 @@ FROM fedora:39 AS base
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN groupadd -g 998 build-user && \
-    useradd -m -r -u 998 -g build-user build-user
-
 RUN yum -y install \
   binutils \
   gcc \
@@ -76,10 +73,6 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
-
-USER build-user
-
-WORKDIR /home/build-user
 
 # Print Installed Swift Version
 RUN swift --version


### PR DESCRIPTION
Currently when we run our nightly Debian/fedora images in GitHub Actions we will see the following error:
```
node:fs:2368
    return binding.writeFileUtf8(
                   ^

Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_e5a8d9b3-2d5c-42c4-be33-8e81a5c7a889'
    at Object.writeFileSync (node:fs:2368:20)
    at Object.appendFileSync (node:fs:2449:6)
    at Object.issueFileCommand (/__w/_actions/actions/checkout/v4/dist/index.js:3060:8)
    at Object.saveState (/__w/_actions/actions/checkout/v4/dist/index.js:2977:31)
    at 4866 (/__w/_actions/actions/checkout/v4/dist/index.js:2402:10)
    at __nccwpck_require__ (/__w/_actions/actions/checkout/v4/dist/index.js:38210:43)
    at 2565 (/__w/_actions/actions/checkout/v4/dist/index.js:150:34)
    at __nccwpck_require__ (/__w/_actions/actions/checkout/v4/dist/index.js:38210:43)
    at 9210 (/__w/_actions/actions/checkout/v4/dist/index.js:1171:36)
    at __nccwpck_require__ (/__w/_actions/actions/checkout/v4/dist/index.js:38210:43) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/__w/_temp/_runner_file_commands/save_state_e5a8d9b3-2d5c-42c4-be33-8e81a5c7a889'
}
```

These images are not directly intended to be used soley by ci.swift.org, they are published, and therefore should not set up a build-user. None of the release images set up the build-user