### PR TITLE
Android: avoid compiler issue swiftlang/swift#55637 when building the stdlib, where it's picking up a module from another arch

### DIFF
--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -498,10 +498,11 @@ for arch in $archs; do
             --foundation-cmake-options=-DCMAKE_SHARED_LINKER_FLAGS= \
             --cross-compile-append-host-target-to-destdir=False 
             # --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
-        # need to remove symlink that gets created in the NDK to the previous arch's build
-        # or else we get errors like:
+        # need to remove the arch-specific portion of the Swift resource dir in
+        # the build directory, through this symlink that we create in the NDK to
+        # the build directory, or else we get errors like:
         # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule
-        rm -f $ndk_installation/sysroot/usr/lib/swift
+        rm -rf $ndk_installation/sysroot/usr/lib/swift/android
     quiet_popd
     groupend
 done


### PR DESCRIPTION
Hopefully, this stops the random flakes we've been seeing on the Android CI, tested by swift-android-sdk/swift-docker#10 externally first.