### PR TITLE
Add zip as a dependency on Linux distributions

### DIFF
--- a/nightly-6.2/fedora/39/Dockerfile
+++ b/nightly-6.2/fedora/39/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  zip \
   unzip \
   libcurl-devel \
   libedit-devel \

--- a/nightly-6.2/fedora/39/buildx/Dockerfile
+++ b/nightly-6.2/fedora/39/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  zip \
   unzip \
   libcurl-devel \
   libedit-devel \

--- a/nightly-6.2/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-6.2/ubuntu/20.04/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    zip \
     unzip \
     gnupg2 \
     libc6-dev \

--- a/nightly-main/fedora/39/Dockerfile
+++ b/nightly-main/fedora/39/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  zip \
   unzip \
   libcurl-devel \
   libedit-devel \

--- a/nightly-main/fedora/39/buildx/Dockerfile
+++ b/nightly-main/fedora/39/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  zip \
   unzip \
   libcurl-devel \
   libedit-devel \

--- a/nightly-main/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/20.04/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    zip \
     unzip \
     gnupg2 \
     libc6-dev \


### PR DESCRIPTION
On Linux, Swift Testing uses the zip package/tool to compress directories when they are recorded as test attachments.

Adds to the nightly 6.2, nightly main and swift-ci main docker containers since this swift testing feature was introduced in 6.2.

This should be merged at the same time as swiftlang/swiftly#451