### PR TITLE
[android] Skip source fetch during android build-docker

### DIFF
--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -85,6 +85,8 @@ CONTAINER_NAME="swift-android"
 $DOCKER build --build-arg OS_ARCH_SUFFIX=$OS_ARCH_SUFFIX --build-arg SWIFT_TOOLCHAIN_URL=$SWIFT_TOOLCHAIN_URL --build-arg ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION -t ${CONTAINER_NAME} .
 
 $DOCKER run -i --rm \
+          -e http_proxy -e https_proxy \
+          -e HTTP_PROXY -e HTTPS_PROXY \
           -v ${WORKDIR}/source:/source \
           -v ${WORKDIR}/products:/products:rw \
           ${CONTAINER_NAME} \

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -82,7 +82,7 @@ fi
 CONTAINER_NAME="swift-android"
 
 # Build the Docker image
-$DOCKER build --build-arg OS_ARCH_SUFFIX=$OS_ARCH_SUFFIX --build-arg SWIFT_TOOLCHAIN_URL=$SWIFT_TOOLCHAIN_URL --build-arg ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION -t ${CONTAINER_NAME} .
+$DOCKER build --build-arg OS_ARCH_SUFFIX=$OS_ARCH_SUFFIX --build-arg SWIFT_TOOLCHAIN_URL=$SWIFT_TOOLCHAIN_URL --build-arg ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION --build-arg http_proxy --build-arg https_proxy --build-arg HTTP_PROXY --build-arg HTTPS_PROXY -t ${CONTAINER_NAME} .
 
 $DOCKER run -i --rm \
           -e http_proxy -e https_proxy \

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -23,6 +23,15 @@ ANDROID_API=28
 BASEPATH=$(dirname $(realpath $0))
 cd ${BASEPATH}
 
+SKIP_FETCH=false
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --skip-fetch) SKIP_FETCH=true ;;
+        *) break ;;
+    esac
+    shift
+done
+
 export SWIFT_VERSION=${1}
 # note that WORKDIR must not be under the current checkout or the patches will fail to apply
 WORKDIR=${2}
@@ -37,7 +46,9 @@ HOST_OS=ubuntu24.04
 source ./scripts/toolchain-vars.sh
 
 # Check-out and patch the sources
-./scripts/fetch-source.sh --source-dir ${WORKDIR}/source
+if [[ "$SKIP_FETCH" != "true" ]]; then
+    ./scripts/fetch-source.sh --source-dir ${WORKDIR}/source
+fi
 
 # This `git grep` invocation in a trunk test fails in our Docker for some
 # reason, so just turn it into a plain `grep` again.

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -55,7 +55,7 @@ fi
 perl -pi -e 's:"git",:#:' ${WORKDIR}/source/swift-project/swift/test/Misc/verify-swift-feature-testing.test-sh
 
 # Work around swiftlang/swift-driver#1822 for now
-perl -pi -g -we "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2if [[ -d \"\\\${ANDROID_NDK}\" ]]; then call ln -sf \"\\\${SWIFT_BUILD_PATH}/lib/swift\" \"\\\${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib\"; fi#" ${WORKDIR}/source/swift-project/swift/utils/build-script-impl
+perl -0777 -pi -e "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2if [[ -d \"\\\${ANDROID_NDK}\" ]]; then call ln -sf \"\\\${SWIFT_BUILD_PATH}/lib/swift\" \"\\\${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib\"; fi#g" ${WORKDIR}/source/swift-project/swift/utils/build-script-impl
 
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' ${WORKDIR}/source/swift-project/swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift


### PR DESCRIPTION
* Add option to skip-fetch so CI users can call fetch-source and build-docker independently as needed 
* Pass necessary env variables for CI environment
* Fix pearl substitution flags

This should allow us to rework our CI job for PR testing to use build-docker