### PR TITLE
[debian 13] set linker to lld in CI container

### DIFF
--- a/swift-ci/main/debian/13/Dockerfile
+++ b/swift-ci/main/debian/13/Dockerfile
@@ -83,6 +83,8 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
     && apt-get purge --auto-remove -y curl
 
+RUN update-alternatives --install /usr/bin/ld ld /opt/swift/6.3/usr/bin/lld 20
+
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 RUN echo PATH="${SWIFT_PREFIX}/usr/bin:${PATH}" >> /etc/profile


### PR DESCRIPTION
* Set linker to lld, gold is deprecated on Debian 13 and ld uses to much memory