### PR TITLE
Fix broken UBI Dockerfiles

### DIFF
--- a/nightly-5.10/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-5.10/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.8/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-5.8/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.9/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-5.9/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.0/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.0/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.1/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.2/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.3/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/rhel-ubi/10/buildx/Dockerfile
+++ b/nightly-6.4.x/rhel-ubi/10/buildx/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.4.x/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/rhel-ubi/10/buildx/Dockerfile
+++ b/nightly-main/rhel-ubi/10/buildx/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-main/rhel-ubi/9/buildx/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version


### PR DESCRIPTION
Some nightly UBI Dockerfiles have unintended dangling backslashes. This causes skipping succeeding `RUN swift --version`.

<https://nickjanetakis.com/blog/beware-of-dangling-backslashes-in-run-commands-in-your-dockerfile>

- related: #520 