### PR TITLE
UBI9: Configurable build user id

### DIFF
--- a/swift-ci/main/rhel-ubi/9/Dockerfile
+++ b/swift-ci/main/rhel-ubi/9/Dockerfile
@@ -1,7 +1,9 @@
 FROM redhat/ubi9
 
-RUN groupadd -g 42 build-user && \
-    useradd -m -r -u 42 -g build-user build-user
+ARG BUILD_USER_ID=42
+
+RUN groupadd -g ${BUILD_USER_ID} build-user && \
+    useradd -m -r -u ${BUILD_USER_ID} -g build-user build-user
 
 RUN yum install -y  \
   git               \


### PR DESCRIPTION
Making the builder-user ID configurable through the docker invocation means that folks can use volumes to map an existing Swift checkout on their host into the container to build in this environment without running into issues with permissions in the build directory.

e.g. `docker build --build-arg BUILD_USER_ID=$(id -u) ...`

By default, the `BUILD_USER_ID` is `42`, matching the existing setup.