### PR TITLE
Static Linux: Add LLVM_TARGETS_TO_BUILD to set architectures explicitly

### DIFF
--- a/swift-ci/sdks/static-linux/scripts/build.sh
+++ b/swift-ci/sdks/static-linux/scripts/build.sh
@@ -347,6 +347,7 @@ run cmake -G Ninja -S ${source_dir}/swift-project/llvm-project/llvm \
     -DLLVM_ENABLE_PROJECTS="clang" \
     -DLLVM_PARALLEL_LINK_JOBS=1 \
     -DCMAKE_INSTALL_PREFIX=${build_dir}/clang
+    -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF"
 
 quiet_pushd ${build_dir}/host/clang
 run ninja -j$parallel_jobs

--- a/swift-ci/sdks/static-linux/scripts/build.sh
+++ b/swift-ci/sdks/static-linux/scripts/build.sh
@@ -347,7 +347,7 @@ run cmake -G Ninja -S ${source_dir}/swift-project/llvm-project/llvm \
     -DLLVM_ENABLE_PROJECTS="clang" \
     -DLLVM_PARALLEL_LINK_JOBS=1 \
     -DCMAKE_INSTALL_PREFIX=${build_dir}/clang
-    -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF"
+    -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;RISCV"
 
 quiet_pushd ${build_dir}/host/clang
 run ninja -j$parallel_jobs


### PR DESCRIPTION
We're not supposed to build with AMDGPU LLVM backend here, otherwise this leads to unsupported code paths:

```
 /home/build-user/source/swift-project/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp:1211: error: invalid conversion from 'llvm::Value*' to 'llvm::CallInst*' [-fpermissive]
```

rdar://184231422